### PR TITLE
Fix URL to murano apps.

### DIFF
--- a/muranodashboard/tests/unit/catalog/test_views.py
+++ b/muranodashboard/tests/unit/catalog/test_views.py
@@ -650,7 +650,7 @@ class TestIndexView(testtools.TestCase):
             'MURANO_USE_GLARE': True,
             'categories': ['foo_category', 'bar_category'],
             'current_category': 'foo_category',
-            'display_repo_url': 'http://apps.openstack.org/#tab=murano-apps',
+            'display_repo_url': 'https://github.com/openstack/murano-apps',
             'is_paginated': None,
             'latest_list': ['foo_app', 'bar_app'],
             'no_apps': False,


### PR DESCRIPTION
I got the message "There are no applications in the catalog. You can import apps from http://apps.openstack.org/#tab=murano-apps. " while opening the App Catalog in Horizon.

But that URL is invalid. I suppose the github repo is the correct one, isn't it?